### PR TITLE
Cluster query update

### DIFF
--- a/AutoPATT.groovy
+++ b/AutoPATT.groovy
@@ -173,7 +173,8 @@ class PhonemicInventory {
 
 class ClusterInventory { 
 	static private PhonexPattern pattern = 
-	PhonexPattern.compile("^\\s<,1>(cluster=\\c\\c+)")
+	/*Phonex pattern for cluster search. Revised to capture tautosyllabic onset clusters in any part of the word*/
+	PhonexPattern.compile("(cluster=(\\c:sctype(\"Onset|LeftAppendix\"))<2,>)")
 	private Map inventoryMap = [:]
 	
 	ClusterInventory(records) {


### PR DESCRIPTION
In this branch, cluster inventory now includes all tautosyllabic onset clusters, not just those in word-initial position.