### PR TITLE
Revert "Cluster query update"

### DIFF
--- a/AutoPATT.groovy
+++ b/AutoPATT.groovy
@@ -173,8 +173,7 @@ class PhonemicInventory {
 
 class ClusterInventory { 
 	static private PhonexPattern pattern = 
-	/*Phonex pattern for cluster search. Revised to capture tautosyllabic onset clusters in any part of the word*/
-	PhonexPattern.compile("(cluster=(\\c:sctype(\"Onset|LeftAppendix\"))<2,>)")
+	PhonexPattern.compile("^\\s<,1>(cluster=\\c\\c+)")
 	private Map inventoryMap = [:]
 	
 	ClusterInventory(records) {


### PR DESCRIPTION
Maintains master with original query including only word-initial consonant clusters. See syllableInitialClusters for alternate branch.

Reverts rayamberg/AutoPATT#28