### PR TITLE
verbose output, base phones, sonority update v0.7

### DIFF
--- a/AutoPATT.groovy
+++ b/AutoPATT.groovy
@@ -1,4 +1,8 @@
+/* AutoPATT version 0.7 */
+
 import au.com.bytecode.opencsv.CSVWriter;
+
+import java.text.SimpleDateFormat;
 
 import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
@@ -13,6 +17,9 @@ import ca.phon.app.session.*;
 import ca.phon.ipa.features.IPAElementComparator;
 import ca.phon.ipa.tree.*;
 import ca.phon.phonex.*;
+
+
+def AutoPATTversion = "0.7"
 
 class PhoneticInventory { 
 	static private IPATokens ipaTokens = new IPATokens()
@@ -120,7 +127,7 @@ class PhonemicInventory {
 						  doneContrast[i] = 1;
 						  /*out.println "Non-match between $p1 and $p2, inventoryMap[$p1] = " +
 						    inventoryMap[p1.getText()];*/
-						  this.out.println "$key/$pair: Found contrast for $p1 and $p2"
+						  /*this.out.println "$key/$pair: Found contrast for $p1 and $p2" */
 						  /*out.println "meanings[$key] = " + meanings[key.toString()] + 
 						    "; meanings[$pair] = " + meanings[pair.toString()]*/
 					    }
@@ -129,7 +136,6 @@ class PhonemicInventory {
 			}
 			doneContrast = []; /*clear doneContrast for next word*/
 		}	
-		
 	}
 
 	/* Modification of ghedlund's function with my additions noted */
@@ -257,6 +263,29 @@ and an interface to output this information. */
   		this.out = out
   	}
   	
+
+	//Method for converting an IPA string to a string of base phones
+	public String getBasePhones(String s) {
+		def basePhones = []
+		String baseString = ""
+		IPATranscript ipa = IPATranscript.parseIPATranscript(s)	
+		def IPAPhones = ipa.findAll {it instanceof Phone}
+		IPAPhones.each {
+			basePhones.add( it.basePhone )
+			baseString = baseString + it.basePhone
+		}
+		return baseString
+	}
+	
+	//Same as above, for a list of IPA strings
+	public List getBasePhonesList (List l) {
+		basePhonesList = []
+		l.each {
+			basePhonesList.add(getBasePhones(it))
+		}
+		return basePhonesList
+	}
+	
   	public List getClusters() {
   		return this.clusterInv.inventory
   	}
@@ -300,10 +329,13 @@ and an interface to output this information. */
 }
 
 class EnglishSpeaker extends Speaker {
+	/* Sonority Values Defined.
+	Affricates are given a sonority value equal to stops per Parker (2002)
+	Could expand this list to provide sonority distance when non-ambient phones occur */
 	private static final SAE_PHONES = [ "p":1, "b":2, "t":1, "d":2, 
-  	"k":1, "ɡ":2, "f":5, "v":6, "θ":5, "ð":6, "s":5, "z":6, 
-  	"ʃ":5, "ʒ":6, "ʧ":3, "ʤ":4, "m":7, "n":7, "ŋ":7, "l":8,
-  	"ɹ":8, "w":9, "j":9, "h":9 ]
+  	"k":1, "ɡ":2, "f":3, "v":4, "θ":3, "ð":4, "s":3, "z":4, 
+  	"ʃ":3, "ʒ":4, "ʧ":1, "ʤ":2, "m":5, "n":5, "ŋ":5, "l":6,
+  	"ɹ":6, "w":7, "j":7, "h":7 ]
   
   	private static final SAE_CLUSTERS = [ "tw", "kw", "pj", "kj", "bj", "pɹ", 
   	  "tɹ", "kɹ", "pl", "kl", "bɹ", "dɹ", "ɡɹ", "bl", "ɡl", "fj", "sw", "fɹ", 
@@ -352,7 +384,7 @@ class EnglishSpeaker extends Speaker {
 		return SAE_CLUSTERS
 	}
 	
-	public List PATT() {
+	public List PATT() {		
 		/* Since PATT steps will be conditionally executed, make them closures
 		and put them in a loop */
 		def methods = [ "Step One":this.&PATTStepOne, 
@@ -362,13 +394,13 @@ class EnglishSpeaker extends Speaker {
 			/* Execute the method as a closure */
 			this.treatmentTargets = methods[pattStep]()
 			if (this.treatmentTargets) {
-				this.out.println("Treatment targets found after $pattStep")
+				this.out.println("\tTreatment targets found after $pattStep")
 				this.csv.writeNext("TARGETS AFTER $pattStep: ")
 				this.csv.writeNext(this.treatmentTargets as String[])
 				return this.treatmentTargets
 			} else {
-				this.out.println("No treatment targets found after $pattStep")
-				this.csv.writeNext("No treatment targets found after $pattStep") 
+				this.out.println("\tNo treatment targets found after $pattStep")
+				this.csv.writeNext("No targets found after $pattStep") 
 			}
 		}
 		this.csv.writeNext("Error: no targets found!")
@@ -376,14 +408,72 @@ class EnglishSpeaker extends Speaker {
 	}
 	
 	private List PATTStepOne() {
-		def targets = []
-		for (cluster in this.clusters ) {
-			IPATranscript ipa = IPATranscript.parseIPATranscript(cluster)
-			if (ipa[0].basePhone == (Character) "s" && cluster.length() >= 3) {
-				this.out.println "Found /s/ cluster"
-				return [];
+		this.out.println "*************************************************************"
+		this.out.println "1. Determine if 3-element /s/CC clusters are appropriate targets"
+		
+		
+		/* Minimum sonority distance and checks for cluster types
+		added to Step One to include in every output */
+		
+		//Examine only 2-element clusters
+//Can be revised to search BASE PHONES
+		def CCInv = this.clusters.findAll{ it.length() == 2 }
+		
+		//Determine if speaker produced adjunct clusters
+		def msd = this.getMinSonorityDistance(CCInv)
+		if (msd == -2) {
+				this.out.println "\tSpeaker produced adjunct (-2 sonority distance) cluster(s)."
+		}
+		
+		//Determine if speaker produced glide clusters:
+		for (cluster in CCInv) {
+			String baseCluster = getBasePhones(cluster)
+			if (baseCluster[1] == "j") {
+				this.out.println "\tSpeaker produced C[j] cluster(s)"
 			}
 		}
+		
+		
+		//Use only viable (true) clusters for minimum sonority distance
+		def exclude = CCInv.findAll{ this.getSonorityDistance(it) == -2 || 
+		["pj", "bj", "fj", "vj", "mj"].contains(it) }
+		def msdPool = CCInv - CCInv.intersect( exclude )		
+
+		msd = this.getMinSonorityDistance(msdPool)		
+		if (msd == null) {
+			this.out.println "\tSpeaker lacks CC clusters to calculate minimum sonority distance"
+		}
+		else {
+			this.out.println "\tMinimum true CC cluster sonority distance: $msd"
+		}
+		
+		def targets = []
+		def sCCInv = []
+		def sCC = false
+		for (cluster in this.clusters ) {
+			//stripped to base phones for length and searching
+			String baseCluster = getBasePhones(cluster)			
+			IPATranscript ipa = IPATranscript.parseIPATranscript(cluster)
+			if (baseCluster[0] == (Character) "s" && baseCluster.length() >= 3) { //"s" does not permit any diacritics
+				sCC = true
+				sCCInv.add( cluster )
+			}	
+		}
+
+		/* Minimum sonority distance for 3-element clusters */
+		//Strip first element from sCC clusters for calculating MSD
+		def sCCmsdPool = []
+		for (cluster in sCCInv) {
+			sCCmsdPool.add( cluster.substring(1) )
+		}
+		if (sCC) {
+			this.out.println "\tSpeaker produced 3-element cluster(s)"
+			msd = this.getMinSonorityDistance(sCCmsdPool)
+			this.out.println "\tSpeaker minimum [s]CC cluster sonority distance: $msd"
+			return []
+		}
+		else println "\tSpeaker does not produce [s]CC clusters"
+		
 		
 		/* if "kw", "pr", "tr", "kr", or "pl" can be constructed from phonemes
 		in the phonemic inventory, prepend /s/ to it and return it as a target.
@@ -398,48 +488,67 @@ class EnglishSpeaker extends Speaker {
 				}
 			}
 		}
+		if ( targets.size() == 0 ) {
+			this.out.println "\tSpeaker's phonemic inventory does not permit 3-element cluster targets"
+		}
 		return targets	
 	}
 
 	private List PATTStepTwo() {
+		this.out.println "\t***************************************************"
+		this.out.println "2. Determine if 2-element CC clusters are appropriate targets"
+
 		def targetPool = this.modelClusters.findAll{it.length() == 2}
 		//this.out.println "PATTStepTwo: targetPool: " + targetPool
-		
-		/* Remove IN clusters */
+				
+		/* a. Remove IN clusters */
 		//this.out.println "PATTStepTwo: Removing IN clusters..."
 		targetPool = targetPool - targetPool.intersect( this.clusters )
 		//this.out.println "PATTStepTwo: targetPool: " + targetPool
 		
-		if (!targetPool) return null
+		if (!targetPool) {
+			this.out.println "\tSpeaker already produced all potential CC cluster targets."
+			return null
+		}		
 		
-		/* Get minimum sonority distance (MSD) and remove all clusters with MSD
-		greater than or equal to that sonority distance */
-		def clusters = this.clusters.findAll{ it.length() == 2 }
-		/* If there aren't any clusters in the inventory, set sonority distance to
-		a number beyond the max. This is a hack that needs to be fixed */
-		def msd = this.getMinSonorityDistance(clusters)
-		if (msd == null) msd = 10
-		//this.out.println "PATTStepTwo: msd: $msd"
-		def removables = targetPool.findAll{ this.getSonorityDistance(it) >= msd }
-		//this.out.println "PATTStepTwo: removables: $removables"
-		targetPool = targetPool - targetPool.intersect( removables )
-		//this.out.println "PATTStepTwo: Removed clusters with msd >= $msd"
-		//this.out.println "PATTStepTwo: targetPool: " + targetPool
+		/* b. Remove clusters with SD=-2 and /C/j clusters 
+		/*Adjunct and glide clusters are skipped due to inconsistent generalization in research*/
+		this.out.println "\tAdjunct and C[j] cluster targets may not\n\t\tbe as effective targets and have been omitted."
+		this.out.println "\t\t(Barlow, 2001; Gierut, 1999; Smit, 1993;\n\t\tSmit, Hand, Freilinger, Bernthal, & Bird, 1990)."	
 		
-		if (!targetPool) return null
-		
-		/* Remove clusters with SD=-2 and /C/j clusters 
-		   Note: due to changes in sonority, SD=-2 is now SD=-4*/
-		removables = targetPool.findAll{ this.getSonorityDistance(it) == -4 || 
+		def removables = targetPool.findAll{ this.getSonorityDistance(it) == -2 || 
 		["pj", "bj", "fj", "vj", "mj"].contains(it) }
 		//this.out.println "PATTStepTwo: removables: $removables"
 		targetPool = targetPool - targetPool.intersect( removables )
 		//this.out.println "PATTStepTwo: Removed /C/j clusters and SD=-2 clusters"
 		//this.out.println "PATTStepTwo: targetPool: " + targetPool
 		
-		if (!targetPool) return null
-			
-		/* If the pool contains /sw, sl, sm, or sn/ determine the error pattern
+		if (!targetPool) {
+			this.out.println "\tOnly adjunct or glide CC clusters available."
+			return null
+		}
+		/* c. Get minimum sonority distance (MSD) and remove all clusters with MSD
+		greater than or equal to that sonority distance */
+		def clusters = this.clusters.findAll{ it.length() == 2 }
+		/* If there aren't any clusters in the inventory, set sonority distance to
+		a number beyond the max. This is a hack that needs to be fixed */
+		def msd = this.getMinSonorityDistance(clusters)
+		if (msd == null) {
+			msd = 10
+			this.out.println "\tSpeaker produced no clusters."
+		}
+		removables = targetPool.findAll{ this.getSonorityDistance(it) >= msd }
+		//this.out.println "PATTStepTwo: removables: $removables"
+		targetPool = targetPool - targetPool.intersect( removables )
+		//this.out.println "PATTStepTwo: Removed clusters with msd >= $msd"
+		//this.out.println "PATTStepTwo: targetPool: " + targetPool
+		
+		if (!targetPool) {
+			this.out.println "\tNo appropriate cluster targets with sonority distance\n\t\tlower than speaker's minimum"
+			return null
+		}
+
+		/* d. If the pool contains /sw, sl, sm, or sn/ determine the error pattern
   in these clusters, e.g. /sn/->/s/ or /sn/->n. If error patterns are similar to
   /sp, st, sk/, remove the clusters. If they are different, keep them in pool. 
   If it is unclear, remove the clusters. Right now we are just outputting what
@@ -450,19 +559,25 @@ class EnglishSpeaker extends Speaker {
 		if (removables) {
 			/* This is where the potential 2-element clusters can be added
 			to the CSV file */
-			this.out.println "PATTStepTwo: Consider " + removables.join(",")
-			this.csv.writeNext("Potential Cluster Targets after Step Two: ")
-			this.csv.writeNext(removables as String[])
+			this.out.println "\t[" + removables.join(",") + "] could be appropriate targets, although\n\t\tgeneralization may be less predictable (Gierut, 1999)."
+			//May want to move this to another place in the printout and edit.
+			//this.csv.writeNext("Potential Cluster Targets after Step Two: ")
+			//this.csv.writeNext(removables as String[])
 		}
 		//this.out.println "PATTStepTwo: Removed sw, sl, sm, sn for now"
 		//this.out.println "PATTStepTwo: targetPool: " + targetPool
 		
 		if (!targetPool) return null
 			
-		/* Find smallest sonority distance in targetPool. If there is more
+		/* e. Find smallest sonority distance in targetPool. If there is more
 	than one, find those with two OUT phones and return them as a treatment
 	target list. */
 		msd = this.getMinSonorityDistance(targetPool)
+
+		if (msd == null) {
+			this.out.println "\tSpeaker produced no viable clusters."
+		}
+			
 		removables = targetPool.findAll{ this.getSonorityDistance(it) > msd }
 		targetPool = targetPool - targetPool.intersect( removables )
 		//this.out.println "PATTStepTwo: Removed all from target pool >= $msd"
@@ -470,18 +585,22 @@ class EnglishSpeaker extends Speaker {
 		def targets = []
 		for (cluster in targetPool) {		
 			// Add clusters from pool for which both segments are OUT phones
+			// Modification can be made here to list more potential targets
 			if (this.outPhones.contains(cluster[0]) && this.outPhones.contains(cluster[1])) {
 			    targets.add(cluster)
-			    break
-			  }
+			}
 		}
 		return targets
 	}	
 
 	private List PATTStepThree() {
+		this.out.println "\t***************************************************"
+		this.out.println "3. Select a singleton target"
+		
 		def targetPool = this.outPhones
 		/* First, remove all stimulable sounds: since we haven't implemented 
 		stimulable sounds yet, skipping this...*/
+		this.out.println "\tAlthough recommended, AutoPATT does not consider\n\t\tstimulability for singleton target selection."
 		
 		/* Cross out early acquired sounds. For english this is [p, b, t, d, k, g,
 		f, v, m, n, ŋ, w, j, h] */
@@ -604,9 +723,12 @@ class EnglishSpeaker extends Speaker {
 }
 
 class SpanishSpeaker extends Speaker {
+	//Sonority Values Defined.
+	//Affricates are given a sonority value equal to stops per Parker (2002)
+	//Could expand this list to provide sonority distance when non-ambient phones occur.		
 	private static final ESP_PHONES = [ "p":1, "b":2, "t":1, "d":2, 
-  	"k":1, "ɡ":2, "f":3, "s":3, "x":3, "ʧ":4, "m":5, "n":5, "ɲ":5, "r":6,
-  	"ɾ":6, "w":7, "β":7, "ð":7, "l":7, "j":7, "ɣ":7 ]
+  	"k":1, "ɡ":2, "f":3, "s":3, "x":3, "ʧ":1, "m":5, "n":5, "ɲ":5, "r":6,
+  	"ɾ":6, "w":7, "β":2, "ð":2, "l":6, "j":7, "ɣ":2 ]
 	
   	private static final ESP_CLUSTERS = [ "pw", "tw", "kw", "pj", "tj", "kj", 
   	  "bw", "dw", "ɡw", "bj", "dj", "ɡj", "pɾ", "tɾ", "kɾ", "pl", "kl", "fw",
@@ -676,13 +798,13 @@ class SpanishSpeaker extends Speaker {
 		for (pattStep in methods.keySet()) {
 			this.treatmentTargets = methods[pattStep]()
 			if (this.treatmentTargets) {
-				this.out.println("Treatment targets found after $pattStep")
-				this.csv.writeNext("TARGETS AFTER $pattStep: ")
-				this.csv.writeNext(this.treatmentTargets as String[])
+				this.out.println("\tTreatment targets found after $pattStep")
+				this.csv.writeNext("TARGET(S) AFTER $pattStep: ")
+				this.csv.writeNext(this.treatmentTargets as String[])	
 				return this.treatmentTargets
 			} else {
-				this.out.println("No treatment targets found after $pattStep")
-				this.csv.writeNext("No treatment targets found after $pattStep") 
+				this.out.println("\tNo treatment targets found after $pattStep")
+				this.csv.writeNext("No targets found after $pattStep") 
 			}
 		}
 		this.csv.writeNext("Error: no targets found!")
@@ -690,6 +812,9 @@ class SpanishSpeaker extends Speaker {
 	}
 	
 	private List PATTStepOne() {		
+		this.out.println "*************************************************************"
+		this.out.println "1. Determine if 2-element CC clusters are appropriate targets"
+		
 		/* Algorithm: you'll have two separate cluster lists. One for C+/w,j/ 
 		clusters, and one for C+/l,r/ clusters. This might involve modifying the
 		cluster inventory for Spanish.*/
@@ -697,34 +822,51 @@ class SpanishSpeaker extends Speaker {
 		def LRClusters = this.clusters.intersect( this.modelLRClusters )
 		def WJTargetPool = this.modelWJClusters
 		def LRTargetPool = this.modelLRClusters
-		/* 1. cross out all IN clusters from both charts. If both empty go to 
+		/* a. cross out all IN clusters from both charts. If both empty go to 
 		Step 2. */
 		WJTargetPool = WJTargetPool - WJTargetPool.intersect(WJClusters)
 		LRTargetPool = LRTargetPool - LRTargetPool.intersect(LRClusters)
-		if (!(WJTargetPool || LRTargetPool)) return null
-		
-		/* 2. Get MSD for /w,j/ clusters. Cross out all clusters >= MSD.*/
+		if (!(WJTargetPool || LRTargetPool)) {
+			this.out.println "\tSpeaker already produced all potential CC cluster targets."
+			return null
+		}
+		/* b. Get MSD for /w,j/ clusters. Cross out all clusters >= MSD.*/
 		if (WJTargetPool) {
-			this.out.println "PATTStepOne: Looking at C+/w,j/ clusters"
+			this.out.println "\t** Examining C+[w,j] clusters **"
 			def msd = this.getMinSonorityDistance(WJClusters)
-			if (msd == null) msd = 10
+			if (msd == null) {
+				msd = 10
+				this.out.println "\tSpeaker produced no C+Glide clusters. Minimum sonority distance not calculated."
+			}
+			else {
+				this.out.println "\tSpeaker's minimum C+Glide cluster sonority distance: $msd"
+			}			
+			
 			def removables = WJTargetPool.findAll{ this.getSonorityDistance(it) >= msd }
 			WJTargetPool = WJTargetPool - WJTargetPool.intersect( removables )
 		}
 	   
-		/*3. Get MSD for /l,r/ clusters. Cross out all clusers >= MSD. */
+		/*c-1. Get MSD for /l,r/ clusters. Cross out all clusters >= MSD. */
 		if (LRTargetPool) {
-			this.out.println "PATTStepOne: Looking at C+/l,ɾ/ clusters"
+			this.out.println "\t** Examining C+[l,ɾ] clusters **"
 			def msd = this.getMinSonorityDistance(LRClusters)
-			if (msd == null) msd = 10
+			if (msd == null) {
+				msd = 10
+				this.out.println "\tSpeaker produced no C+Liquid clusters. Minimum sonority distance not calculated."
+			}
+			else {
+				this.out.println "\tSpeaker's minimum C+Liquid cluster sonority distance: $msd"
+			}	
 			def removables = LRTargetPool.findAll{ this.getSonorityDistance(it) >= msd }
 			LRTargetPool = LRTargetPool - LRTargetPool.intersect( removables )
 		}
 		
-		/* 4. If pool empty, go to Step 2. */
-		if (!(WJTargetPool || LRTargetPool)) return null
-		
-		/*5. Choose clusters with smallest sonority distance. If more than one is 
+		/* c-2. If pool empty, go to Step 2. */
+		if (!(WJTargetPool || LRTargetPool)) {
+			this.out.println "\tNo appropriate cluster targets with sonority distance\n\t\tlower than speaker's minimum."
+			return null
+		}
+		/*d. Choose clusters with smallest sonority distance. If more than one is 
 		chosen, select one that includes OUT phones. If there are more than one,
 		consider selecting one of each type from /w,j/ and /l,r/. Those will be 
 		your treatment targets. Return targets */
@@ -742,6 +884,9 @@ class SpanishSpeaker extends Speaker {
 	}
 	
 	private List PATTStepTwo() {
+		this.out.println "\t***************************************************"
+		this.out.println "3. Select a singleton target"		
+		
 		/* Algorithm:
 		1. Get all out phones.
 		2. Cross out all stimulable sounds
@@ -879,7 +1024,7 @@ if (filename == null) {
   csv = new CSVWriter(new FileWriter(filename))
 } 
 
-	
+/* Allow user to select sessions for analysis */
 def sessionSelector = new SessionSelector(project)
 def scroller = new JScrollPane(sessionSelector)
 JOptionPane.showMessageDialog(window, scroller, "Select Sessions", JOptionPane.INFORMATION_MESSAGE)
@@ -887,11 +1032,18 @@ JOptionPane.showMessageDialog(window, scroller, "Select Sessions", JOptionPane.I
 def sessions = sessionSelector.selectedSessions;
 if(sessions.size() == 0) return
 
+/* Establish sessions and records for analysis */
 records = []
 sessions.each { sessionLoc ->
 	session = project.openSession(sessionLoc.corpus, sessionLoc.session)
 	count = session.getRecordCount()
 	println "Session: $sessionLoc \n\t $count records"
+	
+	/* Add session and record information to output */
+	csv.writeNext(["Session", "Corpus", "Records"] as String[])
+	csv.writeNext(["$sessionLoc.session", "$sessionLoc.corpus", "$count"] as String[])
+	csv.writeNext("")
+	
 	records += session.records
 }
 
@@ -905,15 +1057,28 @@ if (!userSelection) return
 else speaker = langComboMap[userSelection].newInstance(records,
   getBinding().out, csv)
 
-println " ";
+/* Add language, version number, and date of analysis to shell output */
+println "Language: $userSelection"
+println "AutoPATT version $AutoPATTversion"
+def date = new Date()
+def sdf = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss")
+println "Analysis date: " + sdf.format(date)
+println ""
 println "Phonological Assessment and Treatment Target Selection (PATT)"
 println "*************************************************************"
+println "Target selection occurs in a step-by-step fashion based on\nthe results of the individual speaker’s overall assessment\n(Barlow, Taps, & Storkel, 2010)."
+/* Write initial analysis header to csv output */
+csv.writeNext("AutoPATT version $AutoPATTversion")
+csv.writeNext("Language: $userSelection")
+csv.writeNext("Analysis date:")
+csv.writeNext(sdf.format(date))
+csv.writeNext("")
 speaker.writeCSV(speaker.phoneticInv)
 speaker.writeCSV(speaker.phonemicInv)
 speaker.writeCSV(speaker.clusterInv)
 speaker.PATT()
 println "*************************************************************"
-println "TREATMENT TARGETS: " + speaker.treatmentTargets
+println "RECOMMENDED TREATMENT TARGET(S): " + speaker.treatmentTargets
 println "Phones to monitor: " + speaker.outPhones
 csv.writeNext("Phones to monitor:")
 csv.writeNext(speaker.outPhones as String[] )
@@ -923,6 +1088,9 @@ csv.writeNext(speaker.outPhonemes as String[])
 println "Clusters to monitor: " + speaker.outClusters
 csv.writeNext("Clusters to monitor:")
 csv.writeNext(speaker.outClusters as String[])
+println "\nPlease see output in " + filename
+println "For more detailed information about AutoPATT and PATT, visit https://slhs.sdsu.edu/phont/the-patt/"
 
-println "Please see output in " + filename
+//DEBUG PRINTOUT
+
 csv.close()


### PR DESCRIPTION
1. PhonShell output made more verbose, indicating PATT steps, including justifications with citations.
2. Additional details added to CSV output and removed s+nasal clusters from CSV output.
3. Two methods added to Speaker class for getting base phones.
	These allow AutoPATT to be more precise when searching through inventory items, especially when searching by length.
	These are used to fix bugs with identification of 3-element and 2-element clusters that misidentified diacritics as a segment.
	These can benefit additional areas of script in a later update.
4. Removed minimal pair contrasts from PhonShell output to improve readability.
5. Revised sonority scale for English and Spanish.
6. Fixed order of PATT English Part 2 to reflect instructions.
7. Minimum sonority distance and speaker cluster type output added to English Step 1.
8. Bug fix removing break statement from for loop during 2-element target selection preventing seleciton of more than 1 target.